### PR TITLE
Use base styles instead of section for event description text

### DIFF
--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -250,7 +250,7 @@ const EventDescription = ({ html: initialHTML }) => {
 
   return (
     <Text
-      as="section"
+      as={BaseStyles}
       sx={{ my: [2, 4], fontSize: [2, 3] }}
       dangerouslySetInnerHTML={{ __html: html }}
     />


### PR DESCRIPTION
Minor change after my previous pull request broke some event description styling.
This fixes links; I'm not sure how I accidentally used `as="section"` instead of `as={BaseStyles}`. Sorry about that!