### PR TITLE
migrate away from passHref and legacyBehavior

### DIFF
--- a/components/event.js
+++ b/components/event.js
@@ -8,10 +8,11 @@ const now = (start, end) =>
   new Date() > new Date(start) && new Date() < new Date(end)
 
 const Event = ({ id, slug, title, desc, leader, avatar, start, end, cal }) => (
-  <Link href="/[slug]" as={`/${slug}`} passHref legacyBehavior>
+  <Link href={`/${slug}`} passHref legacyBehavior>
     <Box
       as="a"
       sx={{
+        display: 'block',
         position: 'relative',
         textDecoration: 'none',
         bg: 'elevated',

--- a/components/nav.js
+++ b/components/nav.js
@@ -21,9 +21,8 @@ const NavButton = ({ sx, ...props }) => (
 )
 
 const BackButton = ({ to = '/', text = 'All Events' }) => (
-  <Link href={to} passHref legacyBehavior>
+  <Link href={to}>
     <NavButton
-      as="a"
       title={to === '/' ? 'Back to homepage' : 'Back'}
       sx={{ display: 'flex', width: 'auto', pr: 2 }}
     >

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,18 +40,17 @@ export default ({ months }) => (
         as="footer"
         sx={{
           textAlign: 'center',
-          pb: [4, 5],
-          a: { variant: 'buttons.outline', color: 'secondary', mx: 2 }
+          pb: [4, 5]
         }}
       >
-        <Link href="/past" passHref legacyBehavior>
-          <Button as="a" variant="outline">
+        <Link href="/past">
+          <Button variant="outline" sx={{ color: 'secondary', mx: 2 }}>
             <SkipBack />
             View past events
           </Button>
         </Link>
-        <Link href="/data" passHref legacyBehavior>
-          <Button as="a">
+        <Link href="/data">
+          <Button variant="outline" sx={{ color: 'secondary', mx: 2 }}>
             <Activity />
             Events API
           </Button>


### PR DESCRIPTION
`legacyBehavior` is deprecated and will be removed in a future release. A codemod is available to upgrade your components:

npx @next/codemod@latest new-link .

Learn more: https://nextjs.org/docs/app/building-your-application/upgrading/codemods#remove-a-tags-from-link-components